### PR TITLE
use thin arrows for ocaml lib template

### DIFF
--- a/lib/Templates.re
+++ b/lib/Templates.re
@@ -53,10 +53,10 @@ let rec fib n => {
 
   let ml = {|
 let rec fib n = match n with
-  | 0 => 0
-  | 1 => 1
-  | _ when n < 0 => 0
-  | _ => (fib (n - 1)) + (fib (n - 2))
+  | 0 -> 0
+  | 1 -> 1
+  | _ when n < 0 -> 0
+  | _ -> (fib (n - 1)) + (fib (n - 2))
 |};
 
   module Test = {


### PR DESCRIPTION
Ocaml does not have fat arrows as reason does. Prevents compilation errors after generating a project using the ml option.