### PR TITLE
Update Readme.md with a note about ocaml version installed by homebrew

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -63,6 +63,10 @@ Then go ahead and pin to this repository.
 opam pin add ohai git+https://github.com/jaredly/ohai
 ```
 
+_The current version of ocaml installed by homebrew is `4.05.0`, but ohai expects ocaml verion `4.02.3`, `4.03.0`, or `4.04.0`.
+Run `opam switch 4.04.0` if the opam pin command fails._ 
+
+
 ## Usage
 
 ```


### PR DESCRIPTION
OCaml 4.05.0 is the default version installed by homebrew now, which causes the `opam pin add ohai` command fail because it expects 4.02.3 4.03.0 or 4.04.0. I added a note about this and how to switch to a compatible version with the `opam switch` command.

This addresses issue #4.