### PR TITLE
Enabled project names with dash

### DIFF
--- a/lib/Args.re
+++ b/lib/Args.re
@@ -29,7 +29,7 @@ module Cmds = {
     /* TODO more commands? */
 };
 
-let valid_name_rx = Str.regexp "^[a-z0-9_]+$";
+let valid_name_rx = Str.regexp "^[a-z0-9_-]+$";
 let is_valid_name name => Str.string_match valid_name_rx name 0;
 
 let help = {|Usage: ohai [cmd] [opts]

--- a/ohai.opam
+++ b/ohai.opam
@@ -10,4 +10,4 @@ depends: [
   "reason" {>= "1.13.0"}
   "containers"
 ]
-available: [ ocaml-version >= "4.02" & ocaml-version < "4.05" ]
+available: [ ocaml-version >= "4.02" & ocaml-version <= "4.05" ]


### PR DESCRIPTION
Adding - to the approved characters in project names

```ReasonML
Reason # let valid_name_rx = Str.regexp "^[a-z0-9_-]+$";
let valid_name_rx : Str.regexp = <abstr>
Reason # let is_valid_name name => Str.string_match valid_name_rx name 0;
let is_valid_name : string => bool = <fun>
Reason # is_valid_name "yoooo-hooo";
- : bool = true
```